### PR TITLE
Dropbox should be called 'Dropbox'

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 
 # BrowseEverything
 
-This Gem allows your rails application to access user files from cloud storage.  
-Currently there are drivers implemented for [DropBox](http://www.dropbox.com), 
-[Skydrive](https://skydrive.live.com/), [Google Drive](http://drive.google.com), 
+This Gem allows your rails application to access user files from cloud storage.
+Currently there are drivers implemented for [Dropbox](http://www.dropbox.com),
+[Skydrive](https://skydrive.live.com/), [Google Drive](http://drive.google.com),
 [Box](http://www.box.com), and a server-side directory share.
 
-The gem uses [OAuth](http://oauth.net/) to connect to a user's account and 
-generate a list of single use urls that your application can then use to 
+The gem uses [OAuth](http://oauth.net/) to connect to a user's account and
+generate a list of single use urls that your application can then use to
 download the files.
 
 **This gem does not depend on hydra-head**
@@ -27,18 +27,18 @@ And then execute:
 Or install it yourself as:
 
     $ gem install browse-everything
-   
+
 ### Configuring the gem
- 
+
 After installing the gem, run the generator
 
     $ rails g browse_everything:config
-    
+
 This generator will set up the _config/browse_everything_providers.yml_ file and add the browse-everything engine to your application's routes.
 
-If you prefer not to use the generator, or need info on how to set up providers in the browse_everything_providers.yml, use the info on [Configuring browse-everything](https://github.com/projecthydra/browse-everything/wiki/Configuring-browse-everything).  
+If you prefer not to use the generator, or need info on how to set up providers in the browse_everything_providers.yml, use the info on [Configuring browse-everything](https://github.com/projecthydra/browse-everything/wiki/Configuring-browse-everything).
 
-### Include the CSS and JavaScript 
+### Include the CSS and JavaScript
 
 Add `@import "browse_everything";` to your application.css.scss
 
@@ -47,7 +47,7 @@ Add `//= require browse_everything` to your application.js
 ## Usage
 
 ### Adding Providers
-In order to connect to a provider like [DropBox](http://www.dropbox.com), 
+In order to connect to a provider like [Dropbox](http://www.dropbox.com),
 [Skydrive](https://skydrive.live.com/), [Google Drive](http://drive.google.com), or
 [Box](http://www.box.com), you must provide API keys in _config/browse_everything_providers.yml_.  For info on how to edit this file, see [Configuring browse-everything](https://github.com/projecthydra/browse-everything/wiki/Configuring-browse-everything)
 
@@ -57,8 +57,7 @@ browse-everything can be triggered in two ways -- either via data attributes in 
 
 #### Options
 
-
-| Name            | Type            | Default         | Description                                                    |
+| Name            | Type            | Default         | Description |
 |-----------------|-----------------|-----------------|----------------------------------------------------------------|
 | route           | path (required) | ''              | The base route of the browse-everything engine.                |
 | target          | xpath or jQuery | null            | A form object to add the results to as hidden fields.          |
@@ -68,7 +67,6 @@ browse-everything can be triggered in two ways -- either via data attributes in 
 If a `target` is provided, browse-everything will automatically convert the JSON response to a series of hidden form fields
 that can be posted back to Rails to re-create the array on the server side.
 
-
 #### Via data attributes
 
 To trigger browse-everything using data attributes, set the _data-toggle_ attribute to "browse-everything" on the HTML tag.  This tells the javascript where to attach the browse-everything behaviors. Pass in the options using the _data-route_ and _data-target_ attributes, as in `data-target="#myForm"`.
@@ -76,13 +74,13 @@ To trigger browse-everything using data attributes, set the _data-toggle_ attrib
 For example:
 
 ```html
-<button type="button" data-toggle="browse-everything" data-route="<%=browse_everything_engine.root_path%>" 
+<button type="button" data-toggle="browse-everything" data-route="<%=browse_everything_engine.root_path%>"
   data-target="#myForm" class="btn btn-large btn-success" id="browse">Browse!</button>
 ```
 
 #### Via JavaScript
 
-To trigger browse-everything via javascript, use the .browseEverything() method to attach the behaviors to DOM elements. 
+To trigger browse-everything via javascript, use the .browseEverything() method to attach the behaviors to DOM elements.
 
 ```javascript
 $('#browse').browseEverything(options)
@@ -98,20 +96,19 @@ $('#browse').browseEverything({
 
 See [JavaScript Methods](https://github.com/projecthydra/browse-everything/wiki/JavaScript-Methods) for more info on using javascript to trigger browse-everything.
 
-
-### The Results (Data Structure) 
+### The Results (Data Structure)
 
 browse-everything returns a JSON data structure consisting of an array of URL specifications. Each URL specification
 is a plain object with the following properties:
 
-| Property           | Description                                                                          |
+| Property           | Description |
 |--------------------|--------------------------------------------------------------------------------------|
-| url                | The URL of the selected remote file.                                                 |
+| url                | The URL of the selected remote file. |
 | auth_header        | Any headers that need to be added to the request in order to access the remote file. |
-| expires            | The expiration date/time of the specified URL.                                       |
+| expires            | The expiration date/time of the specified URL. |
 | file_name          | The base name (filename.ext) of the selected file.                                   |
 
-For example, after picking two files from dropbox, 
+For example, after picking two files from dropbox,
 
 If you initialized browse-everything via JavaScript, the results data passed to the `.done()` callback will look like this:
 ```json
@@ -127,19 +124,19 @@ If you initialized browse-everything via JavaScript, the results data passed to 
   }
 ]
 ```
-See [JavaScript Methods](https://github.com/projecthydra/browse-everything/wiki/JavaScript-Methods) for more info on using javascript to trigger browse-everything. 
+See [JavaScript Methods](https://github.com/projecthydra/browse-everything/wiki/JavaScript-Methods) for more info on using javascript to trigger browse-everything.
 
 If you initialized browse-everything via data-attributes and set the _target_ option (via the _data-target_ attribute or via the _target_ option on the javascript method), the results data be written as hidden fields in the `<form>` you've specified as the target.  When the user submits that form, the results will look like this:
 ```ruby
 "selected_files" => {
   "0"=>{
-    "url"=>"https://dl.dropbox.com/fake/filepicker-demo.txt.txt", 
-    "expires"=>"2014-03-31T20:37:36.214Z", 
+    "url"=>"https://dl.dropbox.com/fake/filepicker-demo.txt.txt",
+    "expires"=>"2014-03-31T20:37:36.214Z",
     "file_name"=>"filepicker-demo.txt.txt"
-  }, 
+  },
   "1"=>{
-    "url"=>"https://dl.dropbox.com/fake/Getting%20Started.pdf", 
-    "expires"=>"2014-03-31T20:37:36.731Z", 
+    "url"=>"https://dl.dropbox.com/fake/Getting%20Started.pdf",
+    "expires"=>"2014-03-31T20:37:36.731Z",
     "file_name"=>"Getting Started.pdf"
   }
 }
@@ -174,7 +171,7 @@ end
 ### Examples
 
 See `spec/support/app/views/file_handler/index.html` for an example use case. You can also run `rake app:generate` to
-create a fully-functioning demo app in `spec/internal` (though you will have to create 
+create a fully-functioning demo app in `spec/internal` (though you will have to create
 `spec/internal/config/browse_everything.providers.yml` file with your own configuration info.)
 
 ## Contributing
@@ -185,6 +182,6 @@ create a fully-functioning demo app in `spec/internal` (though you will have to 
 4. Push to the branch (`git push origin my-new-feature`)
 5. Create new Pull Request
 
-## Help 
+## Help
 
 For help with Questioning Authority, contact <hydra-tech@googlegroups.com>.

--- a/lib/browse_everything.rb
+++ b/lib/browse_everything.rb
@@ -11,7 +11,7 @@ module BrowseEverything
   module Driver
     autoload :Base,        'browse_everything/driver/base'
     autoload :FileSystem,  'browse_everything/driver/file_system'
-    autoload :DropBox,     'browse_everything/driver/drop_box'
+    autoload :Dropbox,     'browse_everything/driver/dropbox'
     autoload :SkyDrive,    'browse_everything/driver/sky_drive'
     autoload :Box,         'browse_everything/driver/box'
     autoload :GoogleDrive, 'browse_everything/driver/google_drive'
@@ -23,6 +23,12 @@ module BrowseEverything
         @config = value
       elsif value.kind_of?(String)
         @config = YAML.load(File.read(value))
+
+        if @config.include? 'drop_box'
+          warn "[DEPRECATION] `drop_box` is deprecated.  Please use `dropbox` instead."
+          @config['dropbox'] = @config.delete('drop_box')
+        end
+
       else
         raise InitializationError, "Unrecognized configuration: #{value.inspect}"
       end

--- a/lib/browse_everything/driver/dropbox.rb
+++ b/lib/browse_everything/driver/dropbox.rb
@@ -2,15 +2,15 @@ require 'dropbox_sdk'
 
 module BrowseEverything
   module Driver
-    class DropBox < Base
+    class Dropbox < Base
 
       def icon
         'dropbox'
       end
-      
+
       def validate_config
         unless [:app_key,:app_secret].all? { |key| config[key].present? }
-          raise BrowseEverything::InitializationError, "DropBox driver requires :app_key and :app_secret"
+          raise BrowseEverything::InitializationError, "Dropbox driver requires :app_key and :app_secret"
         end
       end
 
@@ -46,7 +46,7 @@ module BrowseEverything
       end
 
       def auth_link
-        [ auth_flow.start('drop_box'), @csrf ]
+        [ auth_flow.start('dropbox'), @csrf ]
       end
 
       def connect(params,data)

--- a/lib/generators/browse_everything/config_generator.rb
+++ b/lib/generators/browse_everything/config_generator.rb
@@ -8,24 +8,21 @@ class BrowseEverything::ConfigGenerator < Rails::Generators::Base
    2. Modifies your app's routes.rb to mount BrowseEverything at /browse
          """
   source_root File.expand_path('../templates', __FILE__)
-   
+
   def inject_routes
    insert_into_file "config/routes.rb", :after => ".draw do" do
 %{
   mount BrowseEverything::Engine => '/browse'}
    end
-  end 
-  
+  end
+
   def copy_example_config
     copy_file "browse_everything_providers.yml.example", "config/browse_everything_providers.yml"
   end
-  
+
   def insert_file_system_path
-    insert_into_file "config/browse_everything_providers.yml", :before => "# drop_box:" do
+    insert_into_file "config/browse_everything_providers.yml", :before => "# dropbox:" do
       YAML.dump({ 'file_system' => { :home => Rails.root.to_s }})
     end
   end
-  
-
-        
 end

--- a/lib/generators/browse_everything/templates/browse_everything_providers.yml.example
+++ b/lib/generators/browse_everything/templates/browse_everything_providers.yml.example
@@ -2,7 +2,7 @@
 # To make browse-everything aware of a provider, uncomment the info for that provider and add your API key information.
 # The file_system provider can be a path to any directory on the server where your application is running.
 #
-# drop_box:
+# dropbox:
 #   :app_key: YOUR_DROPBOX_APP_KEY
 #   :app_secret: YOUR_DROPBOX_APP_SECRET
 # box:

--- a/spec/fixtures/vcr_cassettes/dropbox.yml
+++ b/spec/fixtures/vcr_cassettes/dropbox.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://DropBoxAppKey:DropBoxAppSecret@api.dropbox.com/1/oauth2/token
+    uri: https://DropboxAppKey:DropboxAppSecret@api.dropbox.com/1/oauth2/token
     body:
       encoding: UTF-8
       string: grant_type=authorization_code&code=FakeDropboxAuthorizationCodeABCDEFG&redirect_uri=http%3A%2F%2Fbrowse.example.edu%2Fbrowse%2Fconnect
@@ -341,7 +341,7 @@ http_interactions:
       X-RequestId: 83bc363934d5a5457cbcbd0fab8b4cfb
     body:
       encoding: UTF-8
-      string: ! '{ "revision": 4009, "rev": "fa900cbb190", "thumb_exists": false, "bytes": 20904, 
+      string: ! '{ "revision": 4009, "rev": "fa900cbb190", "thumb_exists": false, "bytes": 20904,
         "modified": "Sat, 09 Apr 2011 18:54:54 +0000", "client_mtime": "Sat, 09 Apr 2011 18:54:54 +0000",
         "path": "/Writer/Writer FAQ.txt", "is_dir": false, "icon": "page_white_text", "root":
         "dropbox", "mime_type": "text/plain", "size": "20.4 KB" }'
@@ -382,9 +382,9 @@ http_interactions:
       X-RequestId: 83bc363934d5a5457cbcbd0fab8b4cfb
     body:
       encoding: UTF-8
-      string: ! '{ "revision": 2754, "rev": "ac200cbb190", "thumb_exists": false, 
-        "bytes": 988, "modified": "Thu, 14 Oct 2010 08:32:20 +0000", 
-        "client_mtime": "Thu, 14 Oct 2010 08:32:20 +0000", 
+      string: ! '{ "revision": 2754, "rev": "ac200cbb190", "thumb_exists": false,
+        "bytes": 988, "modified": "Thu, 14 Oct 2010 08:32:20 +0000",
+        "client_mtime": "Thu, 14 Oct 2010 08:32:20 +0000",
         "path": "/Writer/Markdown Test.txt", "is_dir": false, "icon": "page_white_text",
         "root": "dropbox", "mime_type": "text/plain", "size": "988 bytes" }'
     http_version: '1.1'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,9 +44,9 @@ module BrowserConfigHelper
         client_id: "BoxClientId",
         client_secret: "BoxClientSecret"
       },
-      "drop_box" => { 
-        app_key: "DropBoxAppKey", 
-        app_secret: "DropBoxAppSecret"
+      "dropbox" => {
+        app_key: "DropboxAppKey",
+        app_secret: "DropboxAppSecret"
       },
       "google_drive" => {
         client_id: "GoogleClientId",

--- a/spec/unit/browser_spec.rb
+++ b/spec/unit/browser_spec.rb
@@ -3,24 +3,24 @@ require File.expand_path('../../spec_helper',__FILE__)
 include BrowserConfigHelper
 
 describe BrowseEverything::Browser do
-  let(:file_config) { 
+  let(:file_config) {
     {
       file_system: { home: '/file/config/home' },
-      drop_box:    { app_key: 'FileConfigKey', app_secret: 'FileConfigSecret' }
+      dropbox:    { app_key: 'FileConfigKey', app_secret: 'FileConfigSecret' }
     }.to_yaml
   }
 
   let(:global_config) {
     {
       file_system: { home: '/global/config/home' },
-      drop_box:    { app_key: 'GlobalConfigKey', app_secret: 'GlobalConfigSecret' }
+      dropbox:    { app_key: 'GlobalConfigKey', app_secret: 'GlobalConfigSecret' }
     }
   }
 
   let(:local_config) {
     {
       file_system: { home: '/local/config/home' },
-      drop_box:    { app_key: 'LocalConfigKey', app_secret: 'LocalConfigSecret' },
+      dropbox:    { app_key: 'LocalConfigKey', app_secret: 'LocalConfigSecret' },
       url_options: url_options
     }
   }
@@ -30,47 +30,47 @@ describe BrowseEverything::Browser do
     subject { BrowseEverything::Browser.new(url_options) }
 
     it "should have 2 providers" do
-      expect(subject.providers.keys).to eq([:file_system,:drop_box])
+      expect(subject.providers.keys).to eq([:file_system, :dropbox])
     end
 
     it "should use the file configuration" do
-      expect(subject.providers[:drop_box].config[:app_key]).to eq('FileConfigKey')
+      expect(subject.providers[:dropbox].config[:app_key]).to eq('FileConfigKey')
     end
   end
 
   describe "global config" do
     before(:each) { BrowseEverything.configure(global_config) }
     subject { BrowseEverything::Browser.new(url_options) }
-    
+
     it "should have 2 providers" do
-      expect(subject.providers.keys).to eq([:file_system,:drop_box])
+      expect(subject.providers.keys).to eq([:file_system, :dropbox])
     end
 
     it "should use the global configuration" do
-      expect(subject.providers[:drop_box].config[:app_key]).to eq('GlobalConfigKey')
+      expect(subject.providers[:dropbox].config[:app_key]).to eq('GlobalConfigKey')
     end
   end
 
   describe "local config" do
     subject { BrowseEverything::Browser.new(local_config) }
-    
+
     it "should have 2 providers" do
-      expect(subject.providers.keys).to eq([:file_system,:drop_box])
+      expect(subject.providers.keys).to eq([:file_system, :dropbox])
     end
 
     it "should use the local configuration" do
-      expect(subject.providers[:drop_box].config[:app_key]).to eq('LocalConfigKey')
+      expect(subject.providers[:dropbox].config[:app_key]).to eq('LocalConfigKey')
     end
   end
 
   describe "unknown provider" do
-    subject { 
+    subject {
       BrowseEverything::Browser.new(local_config.merge(foo: { key: 'bar', secret: 'baz' }))
     }
 
     it "should complain but continue" do
       allow(Rails.logger).to receive(:warn).with('Unknown provider: foo')
-      expect(subject.providers.keys).to eq([:file_system,:drop_box])
+      expect(subject.providers.keys).to eq([:file_system, :dropbox])
     end
   end
 end

--- a/spec/unit/dropbox_spec.rb
+++ b/spec/unit/dropbox_spec.rb
@@ -2,26 +2,26 @@ require File.expand_path('../../spec_helper',__FILE__)
 
 include BrowserConfigHelper
 
-describe BrowseEverything::Driver::DropBox, vcr: { cassette_name: 'dropbox', record: :none } do
+describe BrowseEverything::Driver::Dropbox, vcr: { cassette_name: 'dropbox', record: :none } do
   before(:all)  { stub_configuration   }
   after(:all)   { unstub_configuration }
 
   let(:browser) { BrowseEverything::Browser.new(url_options) }
-  let(:provider) { browser.providers['drop_box'] }
+  let(:provider) { browser.providers['dropbox'] }
   let(:auth_params) { {
     'code' => 'FakeDropboxAuthorizationCodeABCDEFG',
-    'state' => 'GjDcUhPNZrZzdsw%2FghBy2A%3D%3D|drop_box'
+    'state' => 'GjDcUhPNZrZzdsw%2FghBy2A%3D%3D|dropbox'
   } }
   let(:csrf_data) { {'token' => 'GjDcUhPNZrZzdsw%2FghBy2A%3D%3D'} }
 
   it "#validate_config" do
-    expect { BrowseEverything::Driver::DropBox.new({}) }.to raise_error(BrowseEverything::InitializationError)
+    expect { BrowseEverything::Driver::Dropbox.new({}) }.to raise_error(BrowseEverything::InitializationError)
   end
 
   describe "simple properties" do
     subject    { provider                 }
-    its(:name) { should == 'Drop Box'     }
-    its(:key)  { should == 'drop_box'     }
+    its(:name) { should == 'Dropbox'     }
+    its(:key)  { should == 'dropbox'     }
     its(:icon) { should be_a(String)      }
   end
 
@@ -33,7 +33,7 @@ describe BrowseEverything::Driver::DropBox, vcr: { cassette_name: 'dropbox', rec
     context "#auth_link" do
       specify { subject.auth_link[0].should start_with('https://www.dropbox.com/1/oauth2/authorize') }
     end
-    
+
     it "should authorize" do
       subject.connect(auth_params,csrf_data)
       expect(subject).to be_authorized
@@ -59,7 +59,7 @@ describe BrowseEverything::Driver::DropBox, vcr: { cassette_name: 'dropbox', rec
         subject { contents[4] }
         its(:name)     { should == 'iPad intro.pdf'           }
         its(:size)     { should == 208218                 }
-        its(:location) { should == "drop_box:/iPad intro.pdf" }
+        its(:location) { should == "dropbox:/iPad intro.pdf" }
         its(:type)     { should == "application/pdf"          }
         specify        { should_not be_container              }
       end
@@ -75,21 +75,21 @@ describe BrowseEverything::Driver::DropBox, vcr: { cassette_name: 'dropbox', rec
       context "[1]" do
         subject { contents[1] }
         its(:name)     { should == 'About Writer.txt'      }
-        its(:location) { should == "drop_box:/Writer/About Writer.txt" }
+        its(:location) { should == "dropbox:/Writer/About Writer.txt" }
         its(:type)     { should == "text/plain"      }
         specify        { should_not be_container     }
       end
       context "[2]" do
         subject { contents[2] }
         its(:name)     { should == 'Markdown Test.txt'      }
-        its(:location) { should == "drop_box:/Writer/Markdown Test.txt" }
+        its(:location) { should == "dropbox:/Writer/Markdown Test.txt" }
         its(:type)     { should == "text/plain"      }
         specify        { should_not be_container     }
       end
       context "[3]" do
         subject { contents[3] }
         its(:name)     { should == 'Writer FAQ.txt'      }
-        its(:location) { should == "drop_box:/Writer/Writer FAQ.txt" }
+        its(:location) { should == "dropbox:/Writer/Writer FAQ.txt" }
         its(:type)     { should == "text/plain"      }
         specify        { should_not be_container     }
       end
@@ -104,13 +104,13 @@ describe BrowseEverything::Driver::DropBox, vcr: { cassette_name: 'dropbox', rec
   describe "#link_for" do
     before(:each) { provider.connect(auth_params,csrf_data) }
 
-    context "[0]" do 
+    context "[0]" do
       subject { provider.link_for('/Writer/Writer FAQ.txt') }
       specify { subject[0].should == "https://dl.dropboxusercontent.com/1/view/FakeDropboxAccessPath/Writer/Writer%20FAQ.txt" }
       specify { subject[1].should have_key(:expires) }
     end
 
-    context "[1]" do 
+    context "[1]" do
       subject { provider.link_for('/Writer/Markdown Test.txt') }
       specify { subject[0].should == "https://dl.dropboxusercontent.com/1/view/FakeDropboxAccessPath/Writer/Markdown%20Test.txt" }
       specify { subject[1].should have_key(:expires) }


### PR DESCRIPTION
This may be somewhat pedantic, and I will grant you that, but I originally looked into this because I couldn't figure out why I was seeing "Drop Box" in the dropdown for cloud providers. Turns out it was coupled to the name of the driver, so I figured I'd just go through the codebase and refer to Dropbox consistently as "Dropbox."