### PR TITLE
Refactoring callback to be a base method, and rejecting the script from…

### DIFF
--- a/lib/browse_everything/driver/base.rb
+++ b/lib/browse_everything/driver/base.rb
@@ -50,6 +50,18 @@ module BrowseEverything
         nil
       end
 
+      private
+
+        def callback
+          connector_response_url(callback_options)
+        end
+
+        # remove the script_name parameter from the url_options since that is causing issues
+        #   with the route not containing the engine path in rails 4.2.0
+        def callback_options
+          config[:url_options].reject {|k,v| k == :script_name}
+        end
+
     end
   end
 end

--- a/lib/browse_everything/driver/box.rb
+++ b/lib/browse_everything/driver/box.rb
@@ -51,7 +51,6 @@ module BrowseEverything
       end
 
       def auth_link
-        callback = connector_response_url(config[:url_options])
         oauth_client.authorize_url(callback.to_s)
       end
 

--- a/lib/browse_everything/driver/dropbox.rb
+++ b/lib/browse_everything/driver/dropbox.rb
@@ -62,7 +62,7 @@ module BrowseEverything
       private
       def auth_flow
         @csrf ||= {}
-        DropboxOAuth2Flow.new(config[:app_key], config[:app_secret], connector_response_url(config[:url_options]).to_s,@csrf,'token')
+        DropboxOAuth2Flow.new(config[:app_key], config[:app_secret], callback.to_s,@csrf,'token')
       end
 
       def client

--- a/lib/browse_everything/driver/google_drive.rb
+++ b/lib/browse_everything/driver/google_drive.rb
@@ -110,7 +110,6 @@ module BrowseEverything
 
       def oauth_client
         if @client.nil?
-          callback = connector_response_url(config[:url_options])
           @client = Google::APIClient.new
           @client.authorization.client_id = config[:client_id]
           @client.authorization.client_secret = config[:client_secret]

--- a/lib/browse_everything/driver/sky_drive.rb
+++ b/lib/browse_everything/driver/sky_drive.rb
@@ -107,7 +107,6 @@ module BrowseEverything
 
       private
       def oauth_client
-        callback = connector_response_url(config[:url_options])
         Skydrive::Oauth::Client.new(config[:client_id], config[:client_secret], callback.to_s,"wl.skydrive")
         #todo error checking here
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,7 +31,8 @@ module BrowserConfigHelper
   def url_options
     {
       protocol: 'http://',
-      host: 'browse-everything.example.edu'
+      host: 'browse-everything.example.edu',
+      script_name: ''
     }
   end
 

--- a/spec/unit/dropbox_spec.rb
+++ b/spec/unit/dropbox_spec.rb
@@ -32,6 +32,7 @@ describe BrowseEverything::Driver::Dropbox, vcr: { cassette_name: 'dropbox', rec
 
     context "#auth_link" do
       specify { subject.auth_link[0].should start_with('https://www.dropbox.com/1/oauth2/authorize') }
+      specify { subject.auth_link[0].should include('browse%2Fconnect') }
     end
 
     it "should authorize" do


### PR DESCRIPTION
… the url_options so that the url includes the engine name

Without this change in Ruby 2.2.2 with Rails 4.2, the callback is /connect instead of browse/connect.
This causes issues with DropBox not recognizing the callback url and additionally when a response is returned it no longer gets routed to the engine.

I am really not sure why the route is dropping the engine path when the script is set, and why it is being returned if you do not want it by rails.