### PR TITLE
Use checkbox to select all files

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,3 +9,5 @@ require 'rspec/core/rake_task'
 require 'engine_cart/rake_task'
 
 task :default => [:ci]
+require 'jasmine'
+load 'jasmine/tasks/jasmine.rake'

--- a/app/assets/javascripts/browse_everything/behavior.js.coffee
+++ b/app/assets/javascripts/browse_everything/behavior.js.coffee
@@ -37,6 +37,81 @@ $ ->
     $('input.ev-url').each () ->
       $("*[data-ev-location='#{$(this).val()}']").addClass('ev-selected')
 
+  fileIsSelected = (row) ->
+    result = false
+    $('input.ev-url').each () ->
+      if this.value == $(row).data('ev-location')
+        result = true
+    return result
+
+  toggleCheckbox = (box) ->
+    if box.value == "0"
+      $(box).prop('value', "1")
+    else
+      $(box).prop('value', "0")    
+
+  toggleFileSelect = (row) ->
+    row.toggleClass('ev-selected')
+    if row.hasClass('ev-selected')
+      selectFile(row)
+    else
+      unselectFile(row)
+    updateFileCount()
+
+  selectFile = (row) ->
+    target_form = $('form.ev-submit-form')
+    file_location = row.data('ev-location')
+    hidden_input = $("<input type='hidden' class='ev-url' name='selected_files[]'/>").val(file_location)
+    target_form.append(hidden_input)
+
+  unselectFile = (row) ->
+    target_form = $('form.ev-submit-form')
+    file_location = row.data('ev-location')
+    $("form.ev-submit-form input[value='#{file_location}']").remove()
+
+  updateFileCount = () ->
+    count = $('input.ev-url').length
+    files = if count == 1 then "file" else "files"
+    $('.ev-status').html("#{count} #{files} selected")
+
+  toggleBranchSelect = (row) ->
+    if row.hasClass('collapsed')
+      node_id = row.find('td.ev-file-name a.ev-link').attr('href')
+      $('table#file-list').treetable('expandNode',node_id)
+
+  selectAll = (rows) ->
+    rows.each () ->
+      if $(this).data('tt-branch')
+        box = $(this).find('#select_all')[0]
+        $(box).prop('checked', true)
+        $(box).prop('value', "1")
+        toggleBranchSelect($(this))
+      else
+        toggleFileSelect($(this))
+
+  selectChildRows = (row, action) ->
+    $('table#file-list tr').each () ->
+      if $(this).data('tt-parent-id')
+        re = RegExp($(row).data('tt-id'), 'i')
+        if $(this).data('tt-parent-id').match(re)
+          if $(this).data('tt-branch')
+            box = $(this).find('#select_all')[0]
+            $(box).prop('value', action)
+            if action == "1"
+              $(box).prop("checked", true)
+              node_id = $(this).find('td.ev-file-name a.ev-link').attr('href')
+              $('table#file-list').treetable('expandNode',node_id)
+            else
+              $(box).prop("checked", false)
+          else
+            if action == "1"
+              $(this).addClass('ev-selected')
+              selectFile($(this)) unless fileIsSelected($(this))
+            else
+              $(this).removeClass('ev-selected')
+              unselectFile($(this))
+            updateFileCount()
+
   tableSetup = (table) ->
     table.treetable
       expandable: true
@@ -95,6 +170,8 @@ $ ->
       $(node).show()
       sizeColumns(table)
       indicateSelected()
+      if $(node.row).find('#select_all')[0].checked
+        selectAll(rows)
     .always ->
         clearInterval progressIntervalID
         $('body').css('cursor','default')
@@ -161,9 +238,6 @@ $ ->
       $('body').css('cursor','default')
       $('.ev-browser').modal('hide')
       $('#browse-btn').focus()
-
-  $(document).on 'click', '.ev-files table tr', (event) ->
-    $('a.ev-link',this).click() unless event.target.nodeName == 'A'
     
   $(document).on 'click', '.ev-files .ev-container a.ev-link', (event) ->
     event.stopPropagation()
@@ -201,18 +275,7 @@ $ ->
   $(document).on 'click', '.ev-file a', (event) ->
     event.preventDefault()
     target = $(this).closest('*[data-ev-location]')
-    target_form = $('form.ev-submit-form')
-    file_location = target.data('ev-location')
-    target.toggleClass('ev-selected')
-    if target.hasClass('ev-selected')
-      hidden_input = $("<input type='hidden' class='ev-url' name='selected_files[]'/>").val(file_location)
-      target_form.append(hidden_input)
-    else
-      $("form.ev-submit-form input[value='#{file_location}']").remove()
-
-    count = $('input.ev-url').length
-    files = if count == 1 then "file" else "files"
-    $('.ev-status').html("#{count} #{files} selected")
+    toggleFileSelect(target)
 
   $(document).on 'click', '.ev-auth', (event) ->
     event.preventDefault()
@@ -223,6 +286,19 @@ $ ->
       else
         window.setTimeout check_func, 1000
     check_func()
+
+  $(document).on 'change', 'input:checkbox', (event) ->
+    event.stopPropagation()
+    event.preventDefault()
+    toggleCheckbox(this)
+    action = this.value
+    row = $(this).closest('tr')
+    node_id = row.find('td.ev-file-name a.ev-link').attr('href')
+    if row.hasClass('collapsed')
+      $('table#file-list').treetable('expandNode',node_id)
+    else
+      selectChildRows(row, action)
+
 
 auto_toggle = ->
   triggers = $('*[data-toggle=browse-everything]')

--- a/app/assets/javascripts/browse_everything/behavior.js.coffee
+++ b/app/assets/javascripts/browse_everything/behavior.js.coffee
@@ -42,13 +42,7 @@ $ ->
     $('input.ev-url').each () ->
       if this.value == $(row).data('ev-location')
         result = true
-    return result
-
-  toggleCheckbox = (box) ->
-    if box.value == "0"
-      $(box).prop('value', "1")
-    else
-      $(box).prop('value', "0")    
+    return result 
 
   toggleFileSelect = (row) ->
     row.toggleClass('ev-selected')
@@ -208,6 +202,12 @@ $ ->
         fail: -> this 
       }
 
+  $.fn.browseEverything.toggleCheckbox = (box) ->
+    if box.value == "0"
+      $(box).prop('value', "1")
+    else
+      $(box).prop('value', "0") 
+
   $(document).on 'ev.refresh', (event) -> refreshFiles()
     
   $(document).on 'click', 'button.ev-cancel', (event) ->
@@ -290,7 +290,7 @@ $ ->
   $(document).on 'change', 'input:checkbox', (event) ->
     event.stopPropagation()
     event.preventDefault()
-    toggleCheckbox(this)
+    $.fn.browseEverything.toggleCheckbox(this)
     action = this.value
     row = $(this).closest('tr')
     node_id = row.find('td.ev-file-name a.ev-link').attr('href')

--- a/app/views/browse_everything/_file.html.erb
+++ b/app/views/browse_everything/_file.html.erb
@@ -23,6 +23,9 @@
       <% end %>
     <% end %>
   </td>
+  <td role="gridcell" class="ev-directory-select">
+    <%= check_box_tag(:select_all, "0", false, class: "ev-select-all") if file.container? %>
+  </td>
   <td role="gridcell" class="ev-file-size">
     <%= number_to_human_size(file.size).sub(/Bytes/,'bytes') %>
   </td>

--- a/app/views/browse_everything/_files.html.erb
+++ b/app/views/browse_everything/_files.html.erb
@@ -8,6 +8,7 @@
     <thead>
       <tr role="row" tabindex="-1">
         <th role="columnheader">Name</th>
+        <th role="columnheader">Select All?</th>
         <th role="columnheader">Size</th>
         <th role="columnheader">Kind</th>
         <th role="columnheader">Modified</th>

--- a/browse-everything.gemspec
+++ b/browse-everything.gemspec
@@ -41,5 +41,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "factory_girl_rails"
   spec.add_development_dependency "engine_cart"
   spec.add_development_dependency "capybara"
+  spec.add_development_dependency "jasmine", '~> 2.3'
 
 end

--- a/spec/javascripts/behavior_spec.js
+++ b/spec/javascripts/behavior_spec.js
@@ -1,0 +1,9 @@
+describe("toggleCheckbox", function() { 
+
+it("toggles the value between 1 and 0", function() {
+    var html = '<input type="checkbox" name="select_all" id="select_all" value="0" class="ev-select-all"/>';
+    var toggled = $.fn.browseEverything.toggleCheckbox($(html)[0]);
+    expect($(toggled)[0].value).toEqual("1");
+  });
+
+});

--- a/spec/javascripts/helpers/jasmine-jquery.js
+++ b/spec/javascripts/helpers/jasmine-jquery.js
@@ -1,0 +1,838 @@
+/*!
+Jasmine-jQuery: a set of jQuery helpers for Jasmine tests.
+
+Version 2.1.1
+
+https://github.com/velesin/jasmine-jquery
+
+Copyright (c) 2010-2014 Wojciech Zawistowski, Travis Jeffery
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+(function (root, factory) {
+     if (typeof module !== 'undefined' && module.exports) {
+        factory(root, root.jasmine, require('jquery'));
+    } else {
+        factory(root, root.jasmine, root.jQuery);
+    }
+}((function() {return this; })(), function (window, jasmine, $) { "use strict";
+
+  jasmine.spiedEventsKey = function (selector, eventName) {
+    return [$(selector).selector, eventName].toString()
+  }
+
+  jasmine.getFixtures = function () {
+    return jasmine.currentFixtures_ = jasmine.currentFixtures_ || new jasmine.Fixtures()
+  }
+
+  jasmine.getStyleFixtures = function () {
+    return jasmine.currentStyleFixtures_ = jasmine.currentStyleFixtures_ || new jasmine.StyleFixtures()
+  }
+
+  jasmine.Fixtures = function () {
+    this.containerId = 'jasmine-fixtures'
+    this.fixturesCache_ = {}
+    this.fixturesPath = 'spec/javascripts/fixtures'
+  }
+
+  jasmine.Fixtures.prototype.set = function (html) {
+    this.cleanUp()
+    return this.createContainer_(html)
+  }
+
+  jasmine.Fixtures.prototype.appendSet= function (html) {
+    this.addToContainer_(html)
+  }
+
+  jasmine.Fixtures.prototype.preload = function () {
+    this.read.apply(this, arguments)
+  }
+
+  jasmine.Fixtures.prototype.load = function () {
+    this.cleanUp()
+    this.createContainer_(this.read.apply(this, arguments))
+  }
+
+  jasmine.Fixtures.prototype.appendLoad = function () {
+    this.addToContainer_(this.read.apply(this, arguments))
+  }
+
+  jasmine.Fixtures.prototype.read = function () {
+    var htmlChunks = []
+      , fixtureUrls = arguments
+
+    for(var urlCount = fixtureUrls.length, urlIndex = 0; urlIndex < urlCount; urlIndex++) {
+      htmlChunks.push(this.getFixtureHtml_(fixtureUrls[urlIndex]))
+    }
+
+    return htmlChunks.join('')
+  }
+
+  jasmine.Fixtures.prototype.clearCache = function () {
+    this.fixturesCache_ = {}
+  }
+
+  jasmine.Fixtures.prototype.cleanUp = function () {
+    $('#' + this.containerId).remove()
+  }
+
+  jasmine.Fixtures.prototype.sandbox = function (attributes) {
+    var attributesToSet = attributes || {}
+    return $('<div id="sandbox" />').attr(attributesToSet)
+  }
+
+  jasmine.Fixtures.prototype.createContainer_ = function (html) {
+    var container = $('<div>')
+    .attr('id', this.containerId)
+    .html(html)
+
+    $(document.body).append(container)
+    return container
+  }
+
+  jasmine.Fixtures.prototype.addToContainer_ = function (html){
+    var container = $(document.body).find('#'+this.containerId).append(html)
+
+    if (!container.length) {
+      this.createContainer_(html)
+    }
+  }
+
+  jasmine.Fixtures.prototype.getFixtureHtml_ = function (url) {
+    if (typeof this.fixturesCache_[url] === 'undefined') {
+      this.loadFixtureIntoCache_(url)
+    }
+    return this.fixturesCache_[url]
+  }
+
+  jasmine.Fixtures.prototype.loadFixtureIntoCache_ = function (relativeUrl) {
+    var self = this
+      , url = this.makeFixtureUrl_(relativeUrl)
+      , htmlText = ''
+      , request = $.ajax({
+        async: false, // must be synchronous to guarantee that no tests are run before fixture is loaded
+        cache: false,
+        url: url,
+        dataType: 'html',
+        success: function (data, status, $xhr) {
+          htmlText = $xhr.responseText
+        }
+      }).fail(function ($xhr, status, err) {
+          throw new Error('Fixture could not be loaded: ' + url + ' (status: ' + status + ', message: ' + err.message + ')')
+      })
+
+      var scripts = $($.parseHTML(htmlText, true)).find('script[src]') || [];
+
+      scripts.each(function(){
+        $.ajax({
+            async: false, // must be synchronous to guarantee that no tests are run before fixture is loaded
+            cache: false,
+            dataType: 'script',
+            url: $(this).attr('src'),
+            success: function (data, status, $xhr) {
+                htmlText += '<script>' + $xhr.responseText + '</script>'
+            },
+            error: function ($xhr, status, err) {
+                throw new Error('Script could not be loaded: ' + url + ' (status: ' + status + ', message: ' + err.message + ')')
+            }
+        });
+      })
+
+      self.fixturesCache_[relativeUrl] = htmlText;
+  }
+
+  jasmine.Fixtures.prototype.makeFixtureUrl_ = function (relativeUrl){
+    return this.fixturesPath.match('/$') ? this.fixturesPath + relativeUrl : this.fixturesPath + '/' + relativeUrl
+  }
+
+  jasmine.Fixtures.prototype.proxyCallTo_ = function (methodName, passedArguments) {
+    return this[methodName].apply(this, passedArguments)
+  }
+
+
+  jasmine.StyleFixtures = function () {
+    this.fixturesCache_ = {}
+    this.fixturesNodes_ = []
+    this.fixturesPath = 'spec/javascripts/fixtures'
+  }
+
+  jasmine.StyleFixtures.prototype.set = function (css) {
+    this.cleanUp()
+    this.createStyle_(css)
+  }
+
+  jasmine.StyleFixtures.prototype.appendSet = function (css) {
+    this.createStyle_(css)
+  }
+
+  jasmine.StyleFixtures.prototype.preload = function () {
+    this.read_.apply(this, arguments)
+  }
+
+  jasmine.StyleFixtures.prototype.load = function () {
+    this.cleanUp()
+    this.createStyle_(this.read_.apply(this, arguments))
+  }
+
+  jasmine.StyleFixtures.prototype.appendLoad = function () {
+    this.createStyle_(this.read_.apply(this, arguments))
+  }
+
+  jasmine.StyleFixtures.prototype.cleanUp = function () {
+    while(this.fixturesNodes_.length) {
+      this.fixturesNodes_.pop().remove()
+    }
+  }
+
+  jasmine.StyleFixtures.prototype.createStyle_ = function (html) {
+    var styleText = $('<div></div>').html(html).text()
+      , style = $('<style>' + styleText + '</style>')
+
+    this.fixturesNodes_.push(style)
+    $('head').append(style)
+  }
+
+  jasmine.StyleFixtures.prototype.clearCache = jasmine.Fixtures.prototype.clearCache
+  jasmine.StyleFixtures.prototype.read_ = jasmine.Fixtures.prototype.read
+  jasmine.StyleFixtures.prototype.getFixtureHtml_ = jasmine.Fixtures.prototype.getFixtureHtml_
+  jasmine.StyleFixtures.prototype.loadFixtureIntoCache_ = jasmine.Fixtures.prototype.loadFixtureIntoCache_
+  jasmine.StyleFixtures.prototype.makeFixtureUrl_ = jasmine.Fixtures.prototype.makeFixtureUrl_
+  jasmine.StyleFixtures.prototype.proxyCallTo_ = jasmine.Fixtures.prototype.proxyCallTo_
+
+  jasmine.getJSONFixtures = function () {
+    return jasmine.currentJSONFixtures_ = jasmine.currentJSONFixtures_ || new jasmine.JSONFixtures()
+  }
+
+  jasmine.JSONFixtures = function () {
+    this.fixturesCache_ = {}
+    this.fixturesPath = 'spec/javascripts/fixtures/json'
+  }
+
+  jasmine.JSONFixtures.prototype.load = function () {
+    this.read.apply(this, arguments)
+    return this.fixturesCache_
+  }
+
+  jasmine.JSONFixtures.prototype.read = function () {
+    var fixtureUrls = arguments
+
+    for(var urlCount = fixtureUrls.length, urlIndex = 0; urlIndex < urlCount; urlIndex++) {
+      this.getFixtureData_(fixtureUrls[urlIndex])
+    }
+
+    return this.fixturesCache_
+  }
+
+  jasmine.JSONFixtures.prototype.clearCache = function () {
+    this.fixturesCache_ = {}
+  }
+
+  jasmine.JSONFixtures.prototype.getFixtureData_ = function (url) {
+    if (!this.fixturesCache_[url]) this.loadFixtureIntoCache_(url)
+    return this.fixturesCache_[url]
+  }
+
+  jasmine.JSONFixtures.prototype.loadFixtureIntoCache_ = function (relativeUrl) {
+    var self = this
+      , url = this.fixturesPath.match('/$') ? this.fixturesPath + relativeUrl : this.fixturesPath + '/' + relativeUrl
+
+    $.ajax({
+      async: false, // must be synchronous to guarantee that no tests are run before fixture is loaded
+      cache: false,
+      dataType: 'json',
+      url: url,
+      success: function (data) {
+        self.fixturesCache_[relativeUrl] = data
+      },
+      error: function ($xhr, status, err) {
+        throw new Error('JSONFixture could not be loaded: ' + url + ' (status: ' + status + ', message: ' + err.message + ')')
+      }
+    })
+  }
+
+  jasmine.JSONFixtures.prototype.proxyCallTo_ = function (methodName, passedArguments) {
+    return this[methodName].apply(this, passedArguments)
+  }
+
+  jasmine.jQuery = function () {}
+
+  jasmine.jQuery.browserTagCaseIndependentHtml = function (html) {
+    return $('<div/>').append(html).html()
+  }
+
+  jasmine.jQuery.elementToString = function (element) {
+    return $(element).map(function () { return this.outerHTML; }).toArray().join(', ')
+  }
+
+  var data = {
+      spiedEvents: {}
+    , handlers:    []
+  }
+
+  jasmine.jQuery.events = {
+    spyOn: function (selector, eventName) {
+      var handler = function (e) {
+        var calls = (typeof data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)] !== 'undefined') ? data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)].calls : 0
+        data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)] = {
+          args: jasmine.util.argsToArray(arguments),
+          calls: ++calls
+        }
+      }
+
+      $(selector).on(eventName, handler)
+      data.handlers.push(handler)
+
+      return {
+        selector: selector,
+        eventName: eventName,
+        handler: handler,
+        reset: function (){
+          delete data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)]
+        },
+        calls: {
+          count: function () {
+              return data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)] ?
+                data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)].calls : 0;
+          },
+          any: function () {
+              return data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)] ?
+                !!data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)].calls : false;
+          }
+        }
+      }
+    },
+
+    args: function (selector, eventName) {
+      var actualArgs = data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)].args
+
+      if (!actualArgs) {
+        throw "There is no spy for " + eventName + " on " + selector.toString() + ". Make sure to create a spy using spyOnEvent."
+      }
+
+      return actualArgs
+    },
+
+    wasTriggered: function (selector, eventName) {
+      return !!(data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)])
+    },
+
+    wasTriggeredWith: function (selector, eventName, expectedArgs, util, customEqualityTesters) {
+      var actualArgs = jasmine.jQuery.events.args(selector, eventName).slice(1)
+
+      if (Object.prototype.toString.call(expectedArgs) !== '[object Array]')
+        actualArgs = actualArgs[0]
+
+      return util.equals(actualArgs, expectedArgs, customEqualityTesters)
+    },
+
+    wasPrevented: function (selector, eventName) {
+      var spiedEvent = data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)]
+        , args = (jasmine.util.isUndefined(spiedEvent)) ? {} : spiedEvent.args
+        , e = args ? args[0] : undefined
+
+      return e && e.isDefaultPrevented()
+    },
+
+    wasStopped: function (selector, eventName) {
+      var spiedEvent = data.spiedEvents[jasmine.spiedEventsKey(selector, eventName)]
+        , args = (jasmine.util.isUndefined(spiedEvent)) ? {} : spiedEvent.args
+        , e = args ? args[0] : undefined
+
+      return e && e.isPropagationStopped()
+    },
+
+    cleanUp: function () {
+      data.spiedEvents = {}
+      data.handlers    = []
+    }
+  }
+
+  var hasProperty = function (actualValue, expectedValue) {
+    if (expectedValue === undefined)
+      return actualValue !== undefined
+
+    return actualValue === expectedValue
+  }
+
+  beforeEach(function () {
+    jasmine.addMatchers({
+      toHaveClass: function () {
+        return {
+          compare: function (actual, className) {
+            return { pass: $(actual).hasClass(className) }
+          }
+        }
+      },
+
+      toHaveCss: function () {
+        return {
+          compare: function (actual, css) {
+            for (var prop in css){
+              var value = css[prop]
+              // see issue #147 on gh
+              ;if (value === 'auto' && $(actual).get(0).style[prop] === 'auto') continue
+              if ($(actual).css(prop) !== value) return { pass: false }
+            }
+            return { pass: true }
+          }
+        }
+      },
+
+      toBeVisible: function () {
+        return {
+          compare: function (actual) {
+            return { pass: $(actual).is(':visible') }
+          }
+        }
+      },
+
+      toBeHidden: function () {
+        return {
+          compare: function (actual) {
+            return { pass: $(actual).is(':hidden') }
+          }
+        }
+      },
+
+      toBeSelected: function () {
+        return {
+          compare: function (actual) {
+            return { pass: $(actual).is(':selected') }
+          }
+        }
+      },
+
+      toBeChecked: function () {
+        return {
+          compare: function (actual) {
+            return { pass: $(actual).is(':checked') }
+          }
+        }
+      },
+
+      toBeEmpty: function () {
+        return {
+          compare: function (actual) {
+            return { pass: $(actual).is(':empty') }
+          }
+        }
+      },
+
+      toBeInDOM: function () {
+        return {
+          compare: function (actual) {
+            return { pass: $.contains(document.documentElement, $(actual)[0]) }
+          }
+        }
+      },
+
+      toExist: function () {
+        return {
+          compare: function (actual) {
+            return { pass: $(actual).length }
+          }
+        }
+      },
+
+      toHaveLength: function () {
+        return {
+          compare: function (actual, length) {
+            return { pass: $(actual).length === length }
+          }
+        }
+      },
+
+      toHaveAttr: function () {
+        return {
+          compare: function (actual, attributeName, expectedAttributeValue) {
+            return { pass: hasProperty($(actual).attr(attributeName), expectedAttributeValue) }
+          }
+        }
+      },
+
+      toHaveProp: function () {
+        return {
+          compare: function (actual, propertyName, expectedPropertyValue) {
+            return { pass: hasProperty($(actual).prop(propertyName), expectedPropertyValue) }
+          }
+        }
+      },
+
+      toHaveId: function () {
+        return {
+          compare: function (actual, id) {
+            return { pass: $(actual).attr('id') == id }
+          }
+        }
+      },
+
+      toHaveHtml: function () {
+        return {
+          compare: function (actual, html) {
+            return { pass: $(actual).html() == jasmine.jQuery.browserTagCaseIndependentHtml(html) }
+          }
+        }
+      },
+
+      toContainHtml: function () {
+        return {
+          compare: function (actual, html) {
+            var actualHtml = $(actual).html()
+              , expectedHtml = jasmine.jQuery.browserTagCaseIndependentHtml(html)
+
+            return { pass: (actualHtml.indexOf(expectedHtml) >= 0) }
+          }
+        }
+      },
+
+      toHaveText: function () {
+        return {
+          compare: function (actual, text) {
+            var actualText = $(actual).text()
+            var trimmedText = $.trim(actualText)
+
+            if (text && $.isFunction(text.test)) {
+              return { pass: text.test(actualText) || text.test(trimmedText) }
+            } else {
+              return { pass: (actualText == text || trimmedText == text) }
+            }
+          }
+        }
+      },
+
+      toContainText: function () {
+        return {
+          compare: function (actual, text) {
+            var trimmedText = $.trim($(actual).text())
+
+            if (text && $.isFunction(text.test)) {
+              return { pass: text.test(trimmedText) }
+            } else {
+              return { pass: trimmedText.indexOf(text) != -1 }
+            }
+          }
+        }
+      },
+
+      toHaveValue: function () {
+        return {
+          compare: function (actual, value) {
+            return { pass: $(actual).val() === value }
+          }
+        }
+      },
+
+      toHaveData: function () {
+        return {
+          compare: function (actual, key, expectedValue) {
+            return { pass: hasProperty($(actual).data(key), expectedValue) }
+          }
+        }
+      },
+
+      toContainElement: function () {
+        return {
+          compare: function (actual, selector) {
+            return { pass: $(actual).find(selector).length }
+          }
+        }
+      },
+
+      toBeMatchedBy: function () {
+        return {
+          compare: function (actual, selector) {
+            return { pass: $(actual).filter(selector).length }
+          }
+        }
+      },
+
+      toBeDisabled: function () {
+        return {
+          compare: function (actual, selector) {
+            return { pass: $(actual).is(':disabled') }
+          }
+        }
+      },
+
+      toBeFocused: function (selector) {
+        return {
+          compare: function (actual, selector) {
+            return { pass: $(actual)[0] === $(actual)[0].ownerDocument.activeElement }
+          }
+        }
+      },
+
+      toHandle: function () {
+        return {
+          compare: function (actual, event) {
+            if ( !actual || actual.length === 0 ) return { pass: false };
+            var events = $._data($(actual).get(0), "events")
+
+            if (!events || !event || typeof event !== "string") {
+              return { pass: false }
+            }
+
+            var namespaces = event.split(".")
+              , eventType = namespaces.shift()
+              , sortedNamespaces = namespaces.slice(0).sort()
+              , namespaceRegExp = new RegExp("(^|\\.)" + sortedNamespaces.join("\\.(?:.*\\.)?") + "(\\.|$)")
+
+            if (events[eventType] && namespaces.length) {
+              for (var i = 0; i < events[eventType].length; i++) {
+                var namespace = events[eventType][i].namespace
+
+                if (namespaceRegExp.test(namespace))
+                  return { pass: true }
+              }
+            } else {
+              return { pass: (events[eventType] && events[eventType].length > 0) }
+            }
+
+            return { pass: false }
+          }
+        }
+      },
+
+      toHandleWith: function () {
+        return {
+          compare: function (actual, eventName, eventHandler) {
+            if ( !actual || actual.length === 0 ) return { pass: false };
+            var normalizedEventName = eventName.split('.')[0]
+              , stack = $._data($(actual).get(0), "events")[normalizedEventName]
+
+            for (var i = 0; i < stack.length; i++) {
+              if (stack[i].handler == eventHandler) return { pass: true }
+            }
+
+            return { pass: false }
+          }
+        }
+      },
+
+      toHaveBeenTriggeredOn: function () {
+        return {
+          compare: function (actual, selector) {
+            var result = { pass: jasmine.jQuery.events.wasTriggered(selector, actual) }
+
+            result.message = result.pass ?
+              "Expected event " + $(actual) + " not to have been triggered on " + selector :
+              "Expected event " + $(actual) + " to have been triggered on " + selector
+
+            return result;
+          }
+        }
+      },
+
+      toHaveBeenTriggered: function (){
+        return {
+          compare: function (actual) {
+            var eventName = actual.eventName
+              , selector = actual.selector
+              , result = { pass: jasmine.jQuery.events.wasTriggered(selector, eventName) }
+
+            result.message = result.pass ?
+            "Expected event " + eventName + " not to have been triggered on " + selector :
+              "Expected event " + eventName + " to have been triggered on " + selector
+
+            return result
+          }
+        }
+      },
+
+      toHaveBeenTriggeredOnAndWith: function (j$, customEqualityTesters) {
+        return {
+          compare: function (actual, selector, expectedArgs) {
+            var wasTriggered = jasmine.jQuery.events.wasTriggered(selector, actual)
+              , result = { pass: wasTriggered && jasmine.jQuery.events.wasTriggeredWith(selector, actual, expectedArgs, j$, customEqualityTesters) }
+
+              if (wasTriggered) {
+                var actualArgs = jasmine.jQuery.events.args(selector, actual, expectedArgs)[1]
+                result.message = result.pass ?
+                  "Expected event " + actual + " not to have been triggered with " + jasmine.pp(expectedArgs) + " but it was triggered with " + jasmine.pp(actualArgs) :
+                  "Expected event " + actual + " to have been triggered with " + jasmine.pp(expectedArgs) + "  but it was triggered with " + jasmine.pp(actualArgs)
+
+              } else {
+                // todo check on this
+                result.message = result.pass ?
+                  "Expected event " + actual + " not to have been triggered on " + selector :
+                  "Expected event " + actual + " to have been triggered on " + selector
+              }
+
+              return result
+          }
+        }
+      },
+
+      toHaveBeenPreventedOn: function () {
+        return {
+          compare: function (actual, selector) {
+            var result = { pass: jasmine.jQuery.events.wasPrevented(selector, actual) }
+
+            result.message = result.pass ?
+              "Expected event " + actual + " not to have been prevented on " + selector :
+              "Expected event " + actual + " to have been prevented on " + selector
+
+            return result
+          }
+        }
+      },
+
+      toHaveBeenPrevented: function () {
+        return {
+          compare: function (actual) {
+            var eventName = actual.eventName
+              , selector = actual.selector
+              , result = { pass: jasmine.jQuery.events.wasPrevented(selector, eventName) }
+
+            result.message = result.pass ?
+              "Expected event " + eventName + " not to have been prevented on " + selector :
+              "Expected event " + eventName + " to have been prevented on " + selector
+
+            return result
+          }
+        }
+      },
+
+      toHaveBeenStoppedOn: function () {
+        return {
+          compare: function (actual, selector) {
+            var result = { pass: jasmine.jQuery.events.wasStopped(selector, actual) }
+
+            result.message = result.pass ?
+              "Expected event " + actual + " not to have been stopped on " + selector :
+              "Expected event " + actual + " to have been stopped on " + selector
+
+            return result;
+          }
+        }
+      },
+
+      toHaveBeenStopped: function () {
+        return {
+          compare: function (actual) {
+            var eventName = actual.eventName
+              , selector = actual.selector
+              , result = { pass: jasmine.jQuery.events.wasStopped(selector, eventName) }
+
+            result.message = result.pass ?
+              "Expected event " + eventName + " not to have been stopped on " + selector :
+              "Expected event " + eventName + " to have been stopped on " + selector
+
+            return result
+          }
+        }
+      }
+    })
+
+    jasmine.getEnv().addCustomEqualityTester(function(a, b) {
+     if (a && b) {
+       if (a instanceof $ || jasmine.isDomNode(a)) {
+         var $a = $(a)
+
+         if (b instanceof $)
+           return $a.length == b.length && a.is(b)
+
+         return $a.is(b);
+       }
+
+       if (b instanceof $ || jasmine.isDomNode(b)) {
+         var $b = $(b)
+
+         if (a instanceof $)
+           return a.length == $b.length && $b.is(a)
+
+         return $(b).is(a);
+       }
+     }
+    })
+
+    jasmine.getEnv().addCustomEqualityTester(function (a, b) {
+     if (a instanceof $ && b instanceof $ && a.size() == b.size())
+        return a.is(b)
+    })
+  })
+
+  afterEach(function () {
+    jasmine.getFixtures().cleanUp()
+    jasmine.getStyleFixtures().cleanUp()
+    jasmine.jQuery.events.cleanUp()
+  })
+
+  window.readFixtures = function () {
+    return jasmine.getFixtures().proxyCallTo_('read', arguments)
+  }
+
+  window.preloadFixtures = function () {
+    jasmine.getFixtures().proxyCallTo_('preload', arguments)
+  }
+
+  window.loadFixtures = function () {
+    jasmine.getFixtures().proxyCallTo_('load', arguments)
+  }
+
+  window.appendLoadFixtures = function () {
+    jasmine.getFixtures().proxyCallTo_('appendLoad', arguments)
+  }
+
+  window.setFixtures = function (html) {
+    return jasmine.getFixtures().proxyCallTo_('set', arguments)
+  }
+
+  window.appendSetFixtures = function () {
+    jasmine.getFixtures().proxyCallTo_('appendSet', arguments)
+  }
+
+  window.sandbox = function (attributes) {
+    return jasmine.getFixtures().sandbox(attributes)
+  }
+
+  window.spyOnEvent = function (selector, eventName) {
+    return jasmine.jQuery.events.spyOn(selector, eventName)
+  }
+
+  window.preloadStyleFixtures = function () {
+    jasmine.getStyleFixtures().proxyCallTo_('preload', arguments)
+  }
+
+  window.loadStyleFixtures = function () {
+    jasmine.getStyleFixtures().proxyCallTo_('load', arguments)
+  }
+
+  window.appendLoadStyleFixtures = function () {
+    jasmine.getStyleFixtures().proxyCallTo_('appendLoad', arguments)
+  }
+
+  window.setStyleFixtures = function (html) {
+    jasmine.getStyleFixtures().proxyCallTo_('set', arguments)
+  }
+
+  window.appendSetStyleFixtures = function (html) {
+    jasmine.getStyleFixtures().proxyCallTo_('appendSet', arguments)
+  }
+
+  window.loadJSONFixtures = function () {
+    return jasmine.getJSONFixtures().proxyCallTo_('load', arguments)
+  }
+
+  window.getJSONFixture = function (url) {
+    return jasmine.getJSONFixtures().proxyCallTo_('read', arguments)[url]
+  }
+}));

--- a/spec/javascripts/jasmine_spec.rb
+++ b/spec/javascripts/jasmine_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+require 'rake'
+
+# Run the jasmine tests by running the jasmine:ci rake command and parses the output for failures.
+# The spec will fail if any jasmine tests fails.
+describe "Jasmine" do
+  it "expects all jasmine tests to pass" do
+    load_rake_environment ["#{jasmine_path}/lib/jasmine/tasks/jasmine.rake"]
+    jasmine_out = run_task 'jasmine:ci'
+    unless jasmine_out.include? "0 failures"
+      puts "Some of the Jasmine tests failed"
+      puts jasmine_out
+    end
+    expect(jasmine_out).to include "0 failures"
+  end
+end
+
+def jasmine_path
+  Gem.loaded_specs['jasmine'].full_gem_path
+end

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -1,0 +1,124 @@
+# src_files
+#
+# Return an array of filepaths relative to src_dir to include before jasmine specs.
+# Default: []
+#
+# EXAMPLE:
+#
+# src_files:
+#   - lib/source1.js
+#   - lib/source2.js
+#   - dist/**/*.js
+#
+src_files:
+  - public/javascripts/**/*.js
+
+# stylesheets
+#
+# Return an array of stylesheet filepaths relative to src_dir to include before jasmine specs.
+# Default: []
+#
+# EXAMPLE:
+#
+# stylesheets:
+#   - css/style.css
+#   - stylesheets/*.css
+#
+stylesheets:
+  - stylesheets/**/*.css
+
+# helpers
+#
+# Return an array of filepaths relative to spec_dir to include before jasmine specs.
+# Default: ["helpers/**/*.js"]
+#
+# EXAMPLE:
+#
+# helpers:
+#   - helpers/**/*.js
+#
+helpers:
+  - 'helpers/**/*.js'
+
+# spec_files
+#
+# Return an array of filepaths relative to spec_dir to include.
+# Default: ["**/*[sS]pec.js"]
+#
+# EXAMPLE:
+#
+# spec_files:
+#   - **/*[sS]pec.js
+#
+spec_files:
+  - '**/*[sS]pec.js'
+
+# src_dir
+#
+# Source directory path. Your src_files must be returned relative to this path. Will use root if left blank.
+# Default: project root
+#
+# EXAMPLE:
+#
+# src_dir: public
+#
+src_dir:
+
+# spec_dir
+#
+# Spec directory path. Your spec_files must be returned relative to this path.
+# Default: spec/javascripts
+#
+# EXAMPLE:
+#
+# spec_dir: spec/javascripts
+#
+spec_dir:
+
+# spec_helper
+#
+# Ruby file that Jasmine server will require before starting.
+# Returned relative to your root path
+# Default spec/javascripts/support/jasmine_helper.rb
+#
+# EXAMPLE:
+#
+# spec_helper: spec/javascripts/support/jasmine_helper.rb
+#
+spec_helper: spec/javascripts/support/jasmine_helper.rb
+
+# boot_dir
+#
+# Boot directory path. Your boot_files must be returned relative to this path.
+# Default: Built in boot file
+#
+# EXAMPLE:
+#
+# boot_dir: spec/javascripts/support/boot
+#
+boot_dir:
+
+# boot_files
+#
+# Return an array of filepaths relative to boot_dir to include in order to boot Jasmine
+# Default: Built in boot file
+#
+# EXAMPLE
+#
+# boot_files:
+#   - '**/*.js'
+#
+boot_files:
+
+# rack_options
+#
+# Extra options to be passed to the rack server
+# by default, Port and AccessLog are passed.
+#
+# This is an advanced options, and left empty by default
+#
+# EXAMPLE
+#
+# rack_options:
+#   server: 'thin'
+

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -11,7 +11,7 @@
 #   - dist/**/*.js
 #
 src_files:
-  - public/javascripts/**/*.js
+  - assets/application.js
 
 # stylesheets
 #
@@ -51,7 +51,7 @@ helpers:
 #   - **/*[sS]pec.js
 #
 spec_files:
-  - '**/*[sS]pec.js'
+  - '**/*[sS]pec.js*'
 
 # src_dir
 #

--- a/spec/javascripts/support/jasmine_helper.rb
+++ b/spec/javascripts/support/jasmine_helper.rb
@@ -1,0 +1,15 @@
+#Use this file to set/override Jasmine configuration options
+#You can remove it if you don't need it.
+#This file is loaded *after* jasmine.yml is interpreted.
+#
+#Example: using a different boot file.
+#Jasmine.configure do |config|
+#   config.boot_dir = '/absolute/path/to/boot_dir'
+#   config.boot_files = lambda { ['/absolute/path/to/boot_dir/file.js'] }
+#end
+#
+#Example: prevent PhantomJS auto install, uses PhantomJS already on your path.
+#Jasmine.configure do |config|
+#   config.prevent_phantom_js_auto_install = true
+#end
+#

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,7 @@ require 'vcr'
 require 'engine_cart'
 require 'capybara/rails'
 require 'capybara/rspec'
+require 'support/rake'
 
 EngineCart.load_application!
 

--- a/spec/support/rake.rb
+++ b/spec/support/rake.rb
@@ -1,0 +1,41 @@
+require 'rake'
+
+module RakeHelper
+  def load_rake_environment(files)
+    @rake = Rake::Application.new
+    Rake.application = @rake
+    Rake::Task.define_task(:environment)
+    files.each {|file| load file}
+  end
+
+  def run_task(task)
+    capture_stdout_stderr do
+      @rake[task].invoke
+    end
+  end
+
+  # saves original $stdout in variable
+  # set $stdout as local instance of StringIO
+  # yields to code execution
+  # returns the local instance of StringIO
+  # resets $stdout to original value
+  def capture_stdout_stderr
+    out = StringIO.new
+    err = StringIO.new
+    $stdout = out
+    $stderr = err
+    begin
+      yield
+    rescue SystemExit => e
+      puts "error = #{e.inspect}"
+    end
+    return "Output: #{out.string}\n Errors:#{err.string}"
+  ensure
+    $stdout = STDOUT
+    $stdout = STDERR
+  end
+
+  RSpec.configure do |config|
+    config.include RakeHelper
+  end
+end

--- a/spec/views/browse_everything/_file.html.erb_spec.rb
+++ b/spec/views/browse_everything/_file.html.erb_spec.rb
@@ -8,39 +8,69 @@ describe 'browse_everything/_file.html.erb', type: :view do
                      'file.m4v', 1024*1024*1024, Time.now, false
                    )
                }
+  let(:container) {
+                BrowseEverything::FileEntry.new(
+                     'dir_id_01234', 'my_provider:/location/pa/th/dir',
+                     'dir', 0, Time.now, true
+                   )
+               }
   let(:provider) { double("provider") }
   let(:page) { Capybara::Node::Simple.new(rendered) }
 
 
   before do
     allow(view).to receive(:browse_everything_engine).and_return(BrowseEverything::Engine.routes.url_helpers)
-    allow(view).to receive(:file).and_return(file)
     allow(view).to receive(:provider).and_return(provider)
     allow(view).to receive(:path).and_return("path")
     allow(view).to receive(:parent).and_return("parent")
     allow(view).to receive(:provider_name).and_return("my provider")
     allow(provider).to receive(:config).and_return(config)
-    render
   end
 
-  context "file not too big" do
-    let(:config) { { max_upload_file_size: (5*1024*1024*1024) } }
-    it "should draw link" do
-      expect(page).to have_selector("a.ev-link")
+  describe "a file" do
+    before do
+      allow(view).to receive(:file).and_return(file)
+      render
+    end
+    context "file not too big" do
+      let(:config) { { max_upload_file_size: (5*1024*1024*1024) } }
+      it "should draw link" do
+        expect(page).to have_selector("a.ev-link")
+      end
+    end
+
+    context "max not configured" do
+      let(:config) { { } }
+      it "should draw link" do
+        expect(page).to have_selector("a.ev-link")
+      end
+    end
+
+    context "file too big" do
+      let(:config) { { max_upload_file_size: 1024 } }
+      it "should draw link" do
+        expect(page).not_to have_selector("a.ev-link")
+      end
+    end
+
+    context "multi-select" do
+      let(:config) { { } }
+      it "should not have a checkbox" do
+        expect(page).not_to have_selector("input.ev-select-all")
+      end
     end
   end
 
-  context "max not configured" do
-    let(:config) { { } }
-    it "should draw link" do
-      expect(page).to have_selector("a.ev-link")
+  describe "a directory" do
+    before do
+      allow(view).to receive(:file).and_return(container)
+      render
     end
-  end
-
-  context "file too big" do
-    let(:config) { { max_upload_file_size: 1024 } }
-    it "should draw link" do
-      expect(page).not_to have_selector("a.ev-link")
+    context "multi-select" do
+      let(:config) { { } }
+      it "should have the select-all checkbox" do
+        expect(page).to have_selector("input.ev-select-all")
+      end
     end
   end
 


### PR DESCRIPTION
This adds support for selecting all files in a directory. Selecting a checkbox will descend into each subfolder, loading it, and selecting its files.
![select-all](https://cloud.githubusercontent.com/assets/312085/10281834/2e7d6c14-6b45-11e5-8420-c0b43217ec78.png)

